### PR TITLE
VP-241/bugfix/fixed validation order

### DIFF
--- a/src/features/schemas/SettingsFormSchema.ts
+++ b/src/features/schemas/SettingsFormSchema.ts
@@ -7,20 +7,20 @@ export const SettingsFormSchema = () => {
   return yup.object({
     userName: yup
       .string()
-      .matches(/^[A-Za-z0-9_-]+$/, t('userName.matches'))
       .min(6, t('userName.min'))
+      .matches(/^[A-Za-z0-9_-]+$/, t('userName.matches'))
       .max(30, t('userName.max'))
       .required(t('userName.required')),
     firstName: yup
       .string()
-      .matches(/^[A-Za-zА-Яа-я]+$/, t('firstName.matches'))
       .min(1, t('firstName.min'))
+      .matches(/^[A-Za-zА-Яа-я]+$/, t('firstName.matches'))
       .max(50, t('firstName.max'))
       .required(t('firstName.required')),
     lastName: yup
       .string()
-      .matches(/^[A-Za-zА-Яа-я]+$/, t('lastName.matches'))
       .min(1, t('lastName.min'))
+      .matches(/^[A-Za-zА-Яа-я]+$/, t('lastName.matches'))
       .max(50, t('lastName.max'))
       .required(t('lastName.required')),
     city: yup.string().max(30, t('city.max')).nullable(),


### PR DESCRIPTION
Order for validation in yup is important - first .min to validate for minimal amount of symbols, and only then .matches 